### PR TITLE
add visual search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*.pyc
+*.DS_Store
 __pycache__/
 .ipynb_checkpoints
 build/*

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 .ipynb_checkpoints
 build/*
 dist/*
+candidate_models.egg-info/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
-*.pyc
-*.DS_Store
+__pycache__/
+.ipynb_checkpoints
+build/*
+dist/*

--- a/candidate_models/base_models/__init__.py
+++ b/candidate_models/base_models/__init__.py
@@ -334,118 +334,228 @@ class BaseModelPool(UniqueKeyDict):
     Each entry maps from `name` to an activations extractor.
     """
 
-    def __init__(self):
+    def __init__(self, input_size=None):
         super(BaseModelPool, self).__init__()
         self._accessed_base_models = set()
 
-        _key_functions = {
-            'alexnet': lambda: pytorch_model('alexnet', image_size=224),
-            'squeezenet1_0': lambda: pytorch_model('squeezenet1_0', image_size=224),
-            'squeezenet1_1': lambda: pytorch_model('squeezenet1_1', image_size=224),
-            'resnet-18': lambda: pytorch_model('resnet18', image_size=224),
-            'resnet-34': lambda: pytorch_model('resnet34', image_size=224),
-            'resnet-50-pytorch': lambda: pytorch_model('resnet50', image_size=224),
-            'resnet-50-robust': lambda: robust_model('resnet50', image_size=224),
+        if input_size==None:
+            _key_functions = {
+                'alexnet': lambda: pytorch_model('alexnet', image_size=224),
+                'squeezenet1_0': lambda: pytorch_model('squeezenet1_0', image_size=224),
+                'squeezenet1_1': lambda: pytorch_model('squeezenet1_1', image_size=224),
+                'resnet-18': lambda: pytorch_model('resnet18', image_size=224),
+                'resnet-34': lambda: pytorch_model('resnet34', image_size=224),
+                'resnet-50-pytorch': lambda: pytorch_model('resnet50', image_size=224),
+                'resnet-50-robust': lambda: robust_model('resnet50', image_size=224),
 
-            'vgg-16': lambda: keras_model('vgg16', 'VGG16', image_size=224),
-            'vgg-19': lambda: keras_model('vgg19', 'VGG19', image_size=224),
-            'vggface': vggface,
-            'xception': lambda: keras_model('xception', 'Xception', image_size=299),
-            'densenet-121': lambda: keras_model('densenet', 'DenseNet121', image_size=224),
-            'densenet-169': lambda: keras_model('densenet', 'DenseNet169', image_size=224),
-            'densenet-201': lambda: keras_model('densenet', 'DenseNet201', image_size=224),
+                'vgg-16': lambda: keras_model('vgg16', 'VGG16', image_size=224),
+                'vgg-19': lambda: keras_model('vgg19', 'VGG19', image_size=224),
+                'vggface': vggface,
+                'xception': lambda: keras_model('xception', 'Xception', image_size=299),
+                'densenet-121': lambda: keras_model('densenet', 'DenseNet121', image_size=224),
+                'densenet-169': lambda: keras_model('densenet', 'DenseNet169', image_size=224),
+                'densenet-201': lambda: keras_model('densenet', 'DenseNet201', image_size=224),
 
-            'inception_v1': lambda: TFSlimModel.init('inception_v1', preprocessing_type='inception', image_size=224),
-            'inception_v2': lambda: TFSlimModel.init('inception_v2', preprocessing_type='inception', image_size=224),
-            'inception_v3': lambda: TFSlimModel.init('inception_v3', preprocessing_type='inception', image_size=299),
-            'inception_v4': lambda: TFSlimModel.init('inception_v4', preprocessing_type='inception', image_size=299),
-            'inception_resnet_v2': lambda: TFSlimModel.init('inception_resnet_v2', preprocessing_type='inception',
-                                                            image_size=299),
-            'resnet-50_v1': lambda: TFSlimModel.init('resnet-50_v1', net_name='resnet_v1_50', preprocessing_type='vgg',
-                                                     image_size=224, labels_offset=0),
-            'resnet-101_v1': lambda: TFSlimModel.init('resnet-101_v1', net_name='resnet_v1_101',
-                                                      preprocessing_type='vgg',
-                                                      image_size=224, labels_offset=0),
-            'resnet-152_v1': lambda: TFSlimModel.init('resnet-152_v1', net_name='resnet_v1_152',
-                                                      preprocessing_type='vgg',
-                                                      image_size=224, labels_offset=0),
-            # image_size is 299 for resnet-v2, this is a bug in tf-slim.
-            # see https://github.com/tensorflow/models/tree/8b18491b26e4b8271db757a3245008882ea112b3/research/slim:
-            # "ResNet V2 models use Inception pre-processing and input image size of 299"
-            'resnet-50_v2': lambda: TFSlimModel.init('resnet-50_v2', net_name='resnet_v2_50',
-                                                     preprocessing_type='inception',
-                                                     image_size=299),
-            'resnet-101_v2': lambda: TFSlimModel.init('resnet-101_v2', net_name='resnet_v2_101',
-                                                      preprocessing_type='inception',
-                                                      image_size=299),
-            'resnet-152_v2': lambda: TFSlimModel.init('resnet-152_v2', net_name='resnet_v2_152',
-                                                      preprocessing_type='inception',
-                                                      image_size=299),
-            'nasnet_mobile': lambda: TFSlimModel.init('nasnet_mobile', preprocessing_type='inception', image_size=331),
-            'nasnet_large': lambda: TFSlimModel.init('nasnet_large', preprocessing_type='inception', image_size=331),
-            'pnasnet_large': lambda: TFSlimModel.init('pnasnet_large', preprocessing_type='inception', image_size=331),
-            'bagnet9': lambda: bagnet("bagnet9"),
-            'bagnet17': lambda: bagnet("bagnet17"),
-            'bagnet33': lambda: bagnet("bagnet33"),
-            # CORnets. Note that these are only here for the base_model_pool, their commitment works separately
-            # from the models here due to anatomical alignment.
-            'CORnet-Z': lambda: cornet('CORnet-Z'),
-            'CORnet-R': lambda: cornet('CORnet-R'),
-            'CORnet-S': lambda: cornet('CORnet-S'),
+                'inception_v1': lambda: TFSlimModel.init('inception_v1', preprocessing_type='inception', image_size=224),
+                'inception_v2': lambda: TFSlimModel.init('inception_v2', preprocessing_type='inception', image_size=224),
+                'inception_v3': lambda: TFSlimModel.init('inception_v3', preprocessing_type='inception', image_size=299),
+                'inception_v4': lambda: TFSlimModel.init('inception_v4', preprocessing_type='inception', image_size=299),
+                'inception_resnet_v2': lambda: TFSlimModel.init('inception_resnet_v2', preprocessing_type='inception',
+                                                                image_size=299),
+                'resnet-50_v1': lambda: TFSlimModel.init('resnet-50_v1', net_name='resnet_v1_50', preprocessing_type='vgg',
+                                                         image_size=224, labels_offset=0),
+                'resnet-101_v1': lambda: TFSlimModel.init('resnet-101_v1', net_name='resnet_v1_101',
+                                                          preprocessing_type='vgg',
+                                                          image_size=224, labels_offset=0),
+                'resnet-152_v1': lambda: TFSlimModel.init('resnet-152_v1', net_name='resnet_v1_152',
+                                                          preprocessing_type='vgg',
+                                                          image_size=224, labels_offset=0),
+                # image_size is 299 for resnet-v2, this is a bug in tf-slim.
+                # see https://github.com/tensorflow/models/tree/8b18491b26e4b8271db757a3245008882ea112b3/research/slim:
+                # "ResNet V2 models use Inception pre-processing and input image size of 299"
+                'resnet-50_v2': lambda: TFSlimModel.init('resnet-50_v2', net_name='resnet_v2_50',
+                                                         preprocessing_type='inception',
+                                                         image_size=299),
+                'resnet-101_v2': lambda: TFSlimModel.init('resnet-101_v2', net_name='resnet_v2_101',
+                                                          preprocessing_type='inception',
+                                                          image_size=299),
+                'resnet-152_v2': lambda: TFSlimModel.init('resnet-152_v2', net_name='resnet_v2_152',
+                                                          preprocessing_type='inception',
+                                                          image_size=299),
+                'nasnet_mobile': lambda: TFSlimModel.init('nasnet_mobile', preprocessing_type='inception', image_size=331),
+                'nasnet_large': lambda: TFSlimModel.init('nasnet_large', preprocessing_type='inception', image_size=331),
+                'pnasnet_large': lambda: TFSlimModel.init('pnasnet_large', preprocessing_type='inception', image_size=331),
+                'bagnet9': lambda: bagnet("bagnet9"),
+                'bagnet17': lambda: bagnet("bagnet17"),
+                'bagnet33': lambda: bagnet("bagnet33"),
+                # CORnets. Note that these are only here for the base_model_pool, their commitment works separately
+                # from the models here due to anatomical alignment.
+                'CORnet-Z': lambda: cornet('CORnet-Z'),
+                'CORnet-R': lambda: cornet('CORnet-R'),
+                'CORnet-S': lambda: cornet('CORnet-S'),
 
-            'resnet50-SIN': lambda: texture_vs_shape(model_identifier='resnet50-SIN',
-                                                     model_name='resnet50_trained_on_SIN'),
-            'resnet50-SIN_IN': lambda: texture_vs_shape(model_identifier='resnet50-SIN_IN',
-                                                        model_name='resnet50_trained_on_SIN_and_IN'),
-            'resnet50-SIN_IN_IN': lambda: texture_vs_shape(
-                model_identifier='resnet50-SIN_IN_IN',
-                model_name='resnet50_trained_on_SIN_and_IN_then_finetuned_on_IN'),
+                'resnet50-SIN': lambda: texture_vs_shape(model_identifier='resnet50-SIN',
+                                                         model_name='resnet50_trained_on_SIN'),
+                'resnet50-SIN_IN': lambda: texture_vs_shape(model_identifier='resnet50-SIN_IN',
+                                                            model_name='resnet50_trained_on_SIN_and_IN'),
+                'resnet50-SIN_IN_IN': lambda: texture_vs_shape(
+                    model_identifier='resnet50-SIN_IN_IN',
+                    model_name='resnet50_trained_on_SIN_and_IN_then_finetuned_on_IN'),
 
-            'resnext101_32x8d_wsl': lambda: wsl(8),
-            'resnext101_32x16d_wsl': lambda: wsl(16),
-            'resnext101_32x32d_wsl': lambda: wsl(32),
-            'resnext101_32x48d_wsl': lambda: wsl(48),
+                'resnext101_32x8d_wsl': lambda: wsl(8),
+                'resnext101_32x16d_wsl': lambda: wsl(16),
+                'resnext101_32x32d_wsl': lambda: wsl(32),
+                'resnext101_32x48d_wsl': lambda: wsl(48),
 
-            'fixres_resnext101_32x48d_wsl': lambda: fixres(
-                'resnext101_32x48d_wsl',
-                'https://dl.fbaipublicfiles.com/FixRes_data/FixRes_Pretrained_Models/ResNeXt_101_32x48d.pth'),
+                'fixres_resnext101_32x48d_wsl': lambda: fixres(
+                    'resnext101_32x48d_wsl',
+                    'https://dl.fbaipublicfiles.com/FixRes_data/FixRes_Pretrained_Models/ResNeXt_101_32x48d.pth'),
 
-            'dcgan': lambda: dcgan("get_discriminator"),
+                'dcgan': lambda: dcgan("get_discriminator"),
 
-            'convrnn_224': lambda: TFUtilsModel.init(load_median_model, 'convrnn_224', tnn_model=True,
-                                                     preprocessing_type='convrnn', image_size=224, image_resize=None),
-        }
-        # MobileNets
-        for version, multiplier, image_size in [
-            # v1
-            (1, 1.0, 224), (1, 1.0, 192), (1, 1.0, 160), (1, 1.0, 128),
-            (1, 0.75, 224), (1, 0.75, 192), (1, 0.75, 160), (1, 0.75, 128),
-            (1, 0.5, 224), (1, 0.5, 192), (1, 0.5, 160), (1, 0.5, 128),
-            (1, 0.25, 224), (1, 0.25, 192), (1, 0.25, 160), (1, 0.25, 128),
-            # v2
-            (2, 1.4, 224),
-            (2, 1.3, 224),
-            (2, 1.0, 224), (2, 1.0, 192), (2, 1.0, 160), (2, 1.0, 128), (2, 1.0, 96),
-            (2, 0.75, 224), (2, 0.75, 192), (2, 0.75, 160), (2, 0.75, 128), (2, 0.75, 96),
-            (2, 0.5, 224), (2, 0.5, 192), (2, 0.5, 160), (2, 0.5, 128), (2, 0.5, 96),
-            (2, 0.35, 224), (2, 0.35, 192), (2, 0.35, 160), (2, 0.35, 128), (2, 0.35, 96),
-        ]:
-            identifier = f"mobilenet_v{version}_{multiplier}_{image_size}"
-            if (version == 1 and multiplier in [.75, .5, .25]) or (version == 2 and multiplier == 1.4):
-                net_name = f"mobilenet_v{version}_{multiplier * 100:03.0f}"
-            else:
-                net_name = f"mobilenet_v{version}"
-            # arg=arg default value enforces closure:
-            # https://docs.python.org/3/faq/programming.html#why-do-lambdas-defined-in-a-loop-with-different-values-all-return-the-same-result
-            _key_functions[identifier] = \
-                lambda identifier=identifier, image_size=image_size, net_name=net_name, \
-                       multiplier=multiplier: TFSlimModel.init(
-                    identifier, preprocessing_type='inception', image_size=image_size, net_name=net_name,
-                    model_ctr_kwargs={'depth_multiplier': multiplier})
+                'convrnn_224': lambda: TFUtilsModel.init(load_median_model, 'convrnn_224', tnn_model=True,
+                                                         preprocessing_type='convrnn', image_size=224, image_resize=None),
+            }
+            # MobileNets
+            for version, multiplier, image_size in [
+                # v1
+                (1, 1.0, 224), (1, 1.0, 192), (1, 1.0, 160), (1, 1.0, 128),
+                (1, 0.75, 224), (1, 0.75, 192), (1, 0.75, 160), (1, 0.75, 128),
+                (1, 0.5, 224), (1, 0.5, 192), (1, 0.5, 160), (1, 0.5, 128),
+                (1, 0.25, 224), (1, 0.25, 192), (1, 0.25, 160), (1, 0.25, 128),
+                # v2
+                (2, 1.4, 224),
+                (2, 1.3, 224),
+                (2, 1.0, 224), (2, 1.0, 192), (2, 1.0, 160), (2, 1.0, 128), (2, 1.0, 96),
+                (2, 0.75, 224), (2, 0.75, 192), (2, 0.75, 160), (2, 0.75, 128), (2, 0.75, 96),
+                (2, 0.5, 224), (2, 0.5, 192), (2, 0.5, 160), (2, 0.5, 128), (2, 0.5, 96),
+                (2, 0.35, 224), (2, 0.35, 192), (2, 0.35, 160), (2, 0.35, 128), (2, 0.35, 96),
+            ]:
+                identifier = f"mobilenet_v{version}_{multiplier}_{image_size}"
+                if (version == 1 and multiplier in [.75, .5, .25]) or (version == 2 and multiplier == 1.4):
+                    net_name = f"mobilenet_v{version}_{multiplier * 100:03.0f}"
+                else:
+                    net_name = f"mobilenet_v{version}"
+                # arg=arg default value enforces closure:
+                # https://docs.python.org/3/faq/programming.html#why-do-lambdas-defined-in-a-loop-with-different-values-all-return-the-same-result
+                _key_functions[identifier] = \
+                    lambda identifier=identifier, image_size=image_size, net_name=net_name, \
+                           multiplier=multiplier: TFSlimModel.init(
+                        identifier, preprocessing_type='inception', image_size=image_size, net_name=net_name,
+                        model_ctr_kwargs={'depth_multiplier': multiplier})
 
-        # instantiate models with LazyLoad wrapper
-        for identifier, function in _key_functions.items():
-            self[identifier] = LazyLoad(function)
+            # instantiate models with LazyLoad wrapper
+            for identifier, function in _key_functions.items():
+                self[identifier] = LazyLoad(function)
+        else:
+            _key_functions = {
+                'alexnet': lambda: pytorch_model('alexnet', image_size=input_size),
+                'squeezenet1_0': lambda: pytorch_model('squeezenet1_0', image_size=input_size),
+                'squeezenet1_1': lambda: pytorch_model('squeezenet1_1', image_size=input_size),
+                'resnet-18': lambda: pytorch_model('resnet18', image_size=input_size),
+                'resnet-34': lambda: pytorch_model('resnet34', image_size=input_size),
+                'resnet-50-pytorch': lambda: pytorch_model('resnet50', image_size=input_size),
+                'resnet-50-robust': lambda: robust_model('resnet50', image_size=input_size),
+
+                'vgg-16': lambda: keras_model('vgg16', 'VGG16', image_size=input_size),
+                'vgg-19': lambda: keras_model('vgg19', 'VGG19', image_size=input_size),
+                'vggface': vggface,
+                'xception': lambda: keras_model('xception', 'Xception', image_size=input_size),
+                'densenet-121': lambda: keras_model('densenet', 'DenseNet121', image_size=input_size),
+                'densenet-169': lambda: keras_model('densenet', 'DenseNet169', image_size=input_size),
+                'densenet-201': lambda: keras_model('densenet', 'DenseNet201', image_size=input_size),
+
+                'inception_v1': lambda: TFSlimModel.init('inception_v1', preprocessing_type='inception', image_size=input_size),
+                'inception_v2': lambda: TFSlimModel.init('inception_v2', preprocessing_type='inception', image_size=input_size),
+                'inception_v3': lambda: TFSlimModel.init('inception_v3', preprocessing_type='inception', image_size=input_size),
+                'inception_v4': lambda: TFSlimModel.init('inception_v4', preprocessing_type='inception', image_size=input_size),
+                'inception_resnet_v2': lambda: TFSlimModel.init('inception_resnet_v2', preprocessing_type='inception',
+                                                                image_size=input_size),
+                'resnet-50_v1': lambda: TFSlimModel.init('resnet-50_v1', net_name='resnet_v1_50', preprocessing_type='vgg',
+                                                         image_size=input_size, labels_offset=0),
+                'resnet-101_v1': lambda: TFSlimModel.init('resnet-101_v1', net_name='resnet_v1_101',
+                                                          preprocessing_type='vgg',
+                                                          image_size=input_size, labels_offset=0),
+                'resnet-152_v1': lambda: TFSlimModel.init('resnet-152_v1', net_name='resnet_v1_152',
+                                                          preprocessing_type='vgg',
+                                                          image_size=input_size, labels_offset=0),
+                # image_size is 299 for resnet-v2, this is a bug in tf-slim.
+                # see https://github.com/tensorflow/models/tree/8b18491b26e4b8271db757a3245008882ea112b3/research/slim:
+                # "ResNet V2 models use Inception pre-processing and input image size of 299"
+                'resnet-50_v2': lambda: TFSlimModel.init('resnet-50_v2', net_name='resnet_v2_50',
+                                                         preprocessing_type='inception',
+                                                         image_size=input_size),
+                'resnet-101_v2': lambda: TFSlimModel.init('resnet-101_v2', net_name='resnet_v2_101',
+                                                          preprocessing_type='inception',
+                                                          image_size=input_size),
+                'resnet-152_v2': lambda: TFSlimModel.init('resnet-152_v2', net_name='resnet_v2_152',
+                                                          preprocessing_type='inception',
+                                                          image_size=input_size),
+                'nasnet_mobile': lambda: TFSlimModel.init('nasnet_mobile', preprocessing_type='inception', image_size=input_size),
+                'nasnet_large': lambda: TFSlimModel.init('nasnet_large', preprocessing_type='inception', image_size=input_size),
+                'pnasnet_large': lambda: TFSlimModel.init('pnasnet_large', preprocessing_type='inception', image_size=input_size),
+                'bagnet9': lambda: bagnet("bagnet9"),
+                'bagnet17': lambda: bagnet("bagnet17"),
+                'bagnet33': lambda: bagnet("bagnet33"),
+                # CORnets. Note that these are only here for the base_model_pool, their commitment works separately
+                # from the models here due to anatomical alignment.
+                'CORnet-Z': lambda: cornet('CORnet-Z'),
+                'CORnet-R': lambda: cornet('CORnet-R'),
+                'CORnet-S': lambda: cornet('CORnet-S'),
+
+                'resnet50-SIN': lambda: texture_vs_shape(model_identifier='resnet50-SIN',
+                                                         model_name='resnet50_trained_on_SIN'),
+                'resnet50-SIN_IN': lambda: texture_vs_shape(model_identifier='resnet50-SIN_IN',
+                                                            model_name='resnet50_trained_on_SIN_and_IN'),
+                'resnet50-SIN_IN_IN': lambda: texture_vs_shape(
+                    model_identifier='resnet50-SIN_IN_IN',
+                    model_name='resnet50_trained_on_SIN_and_IN_then_finetuned_on_IN'),
+
+                'resnext101_32x8d_wsl': lambda: wsl(8),
+                'resnext101_32x16d_wsl': lambda: wsl(16),
+                'resnext101_32x32d_wsl': lambda: wsl(32),
+                'resnext101_32x48d_wsl': lambda: wsl(48),
+
+                'fixres_resnext101_32x48d_wsl': lambda: fixres(
+                    'resnext101_32x48d_wsl',
+                    'https://dl.fbaipublicfiles.com/FixRes_data/FixRes_Pretrained_Models/ResNeXt_101_32x48d.pth'),
+
+                'dcgan': lambda: dcgan("get_discriminator"),
+
+                'convrnn_224': lambda: TFUtilsModel.init(load_median_model, 'convrnn_224', tnn_model=True,
+                                                         preprocessing_type='convrnn', image_size=224, image_resize=None),
+            }
+            # MobileNets
+            for version, multiplier, image_size in [
+                # v1
+                (1, 1.0, 224), (1, 1.0, 192), (1, 1.0, 160), (1, 1.0, 128),
+                (1, 0.75, 224), (1, 0.75, 192), (1, 0.75, 160), (1, 0.75, 128),
+                (1, 0.5, 224), (1, 0.5, 192), (1, 0.5, 160), (1, 0.5, 128),
+                (1, 0.25, 224), (1, 0.25, 192), (1, 0.25, 160), (1, 0.25, 128),
+                # v2
+                (2, 1.4, 224),
+                (2, 1.3, 224),
+                (2, 1.0, 224), (2, 1.0, 192), (2, 1.0, 160), (2, 1.0, 128), (2, 1.0, 96),
+                (2, 0.75, 224), (2, 0.75, 192), (2, 0.75, 160), (2, 0.75, 128), (2, 0.75, 96),
+                (2, 0.5, 224), (2, 0.5, 192), (2, 0.5, 160), (2, 0.5, 128), (2, 0.5, 96),
+                (2, 0.35, 224), (2, 0.35, 192), (2, 0.35, 160), (2, 0.35, 128), (2, 0.35, 96),
+            ]:
+                identifier = f"mobilenet_v{version}_{multiplier}_{image_size}"
+                if (version == 1 and multiplier in [.75, .5, .25]) or (version == 2 and multiplier == 1.4):
+                    net_name = f"mobilenet_v{version}_{multiplier * 100:03.0f}"
+                else:
+                    net_name = f"mobilenet_v{version}"
+                # arg=arg default value enforces closure:
+                # https://docs.python.org/3/faq/programming.html#why-do-lambdas-defined-in-a-loop-with-different-values-all-return-the-same-result
+                _key_functions[identifier] = \
+                    lambda identifier=identifier, image_size=input_size, net_name=net_name, \
+                           multiplier=multiplier: TFSlimModel.init(
+                        identifier, preprocessing_type='inception', image_size=input_size, net_name=net_name,
+                        model_ctr_kwargs={'depth_multiplier': multiplier})
+
+            # instantiate models with LazyLoad wrapper
+            for identifier, function in _key_functions.items():
+                self[identifier] = LazyLoad(function)
 
     def __getitem__(self, basemodel_identifier):
         if basemodel_identifier in self._accessed_base_models:

--- a/candidate_models/model_commitments/vs_layer.py
+++ b/candidate_models/model_commitments/vs_layer.py
@@ -1,0 +1,26 @@
+import warnings
+
+import itertools
+
+from candidate_models.utils import UniqueKeyDict
+
+class VisualSearchLayers(UniqueKeyDict):
+    def __init__(self):
+        super(VisualSearchLayers, self).__init__()
+        layers = {
+            'vgg-16': [f'block{i + 1}_pool' for i in range(3,5)],
+        }
+        for basemodel_identifier, default_layers in layers.items():
+            self[basemodel_identifier] = default_layers
+
+    @staticmethod
+    def _item(item):
+        return item
+
+    def __getitem__(self, item):
+        return super(VisualSearchLayers, self).__getitem__(self._item(item))
+
+    def __contains__(self, item):
+        return super(VisualSearchLayers, self).__contains__(self._item(item))
+
+visual_search_layer = VisualSearchLayers()

--- a/examples/visual-search-score-model.ipynb
+++ b/examples/visual-search-score-model.ipynb
@@ -1,0 +1,140 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import warnings\n",
+    "warnings.simplefilter(\"ignore\")\n",
+    "\n",
+    "try:\n",
+    "    from tensorflow.python.util import module_wrapper as deprecation\n",
+    "except ImportError:\n",
+    "    from tensorflow.python.util import deprecation_wrapper as deprecation\n",
+    "deprecation._PER_MODULE_WARNING_LIMIT = 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:\n",
+      "The TensorFlow contrib module will not be included in TensorFlow 2.0.\n",
+      "For more information, please see:\n",
+      "  * https://github.com/tensorflow/community/blob/master/rfcs/20180907-contrib-sunset.md\n",
+      "  * https://github.com/tensorflow/addons\n",
+      "  * https://github.com/tensorflow/io (for I/O related ops)\n",
+      "If you depend on functionality not listed there, please file an issue.\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "from candidate_models import score_model\n",
+    "from candidate_models.model_commitments import brain_translated_pool\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "## Starting visual search task...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Using TensorFlow backend.\n",
+      "activations: 100%|██████████| 320/320 [00:01<00:00, 246.05it/s]\n",
+      "layer packaging: 100%|██████████| 1/1 [00:00<00:00, 98.36it/s]\n",
+      "activations: 100%|██████████| 320/320 [00:58<00:00,  5.47it/s]\n",
+      "layer packaging: 100%|██████████| 1/1 [00:00<00:00,  2.16it/s]\n",
+      "visual search stimuli: 100%|██████████| 300/300 [00:59<00:00,  5.08it/s]\n",
+      "comparing with human data:   0%|          | 0/15 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "## Search task done...\n",
+      "\n",
+      "## Calculating score...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "comparing with human data: 100%|██████████| 15/15 [00:07<00:00,  2.13it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "## Score calculated...\n",
+      "\n",
+      "<xarray.Score (aggregation: 2)>\n",
+      "array([0.923438, 0.005427])\n",
+      "Coordinates:\n",
+      "  * aggregation  (aggregation) <U6 'center' 'error'\n",
+      "Attributes:\n",
+      "    raw:                   <xarray.Score (aggregation: 2)>\\narray([0.407328, ...\n",
+      "    ceiling:               <xarray.Score (aggregation: 2)>\\narray([0.4411,   ...\n",
+      "    model_identifier:      vgg-16\n",
+      "    benchmark_identifier:  klab.Zhang2018-ObjArray\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "identifier = 'vgg-16'\n",
+    "model = brain_translated_pool[identifier]\n",
+    "score = score_model(model_identifier=identifier, model=model, benchmark_identifier='klab.Zhang2018-ObjArray')\n",
+    "print(score)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,13 @@
+import pytest
+from pytest import approx
+
+from candidate_models.model_commitments import brain_translated_pool
+from brainscore.benchmarks import benchmark_pool
+import numpy as np
+import matplotlib.pyplot as plt
+import brainscore
+
+def test_search():
+    model = brain_translated_pool['vgg-16']
+    score = score_model(model_identifier='vgg-16', model=model, benchmark_identifier='klab.Zhang2018-ObjArray')
+    assert score.raw.sel(aggregation='center') == approx(0.407328, abs=.005)


### PR DESCRIPTION
- candidate_models/model_commitments/vs_layer.py is added to use pre-defined layers for target and search image.
- candidate_models/base_models/__init__.py : Changes are done to use specific input_size for base_models if specified.

check score_model [example](https://github.com/shashikg/candidate_models/blob/master/examples/visual-search-score-model.ipynb) on visual search benchmark.