### PR TITLE
remove top-level model imports for CORnet/ConvRNN

### DIFF
--- a/candidate_models/base_models/__init__.py
+++ b/candidate_models/base_models/__init__.py
@@ -8,8 +8,6 @@ import numpy as np
 
 from brainscore.utils import LazyLoad, fullname
 from candidate_models import s3
-from candidate_models.base_models.cornet import cornet
-from candidate_models.base_models.convrnn.convrnn_base import load_median_model
 from model_tools.activations import PytorchWrapper, KerasWrapper
 from brainscore.submission.utils import UniqueKeyDict
 from model_tools.activations.tensorflow import TensorflowWrapper, TensorflowSlimWrapper


### PR DESCRIPTION
the imports are actually defined locally in the respective functions, these top-level imports appear to be an old remnant...